### PR TITLE
fix(ios): Add missing usage description required by Camera plugin

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -47,6 +47,8 @@
 	<string>To meet local regulations and laws</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Used when camera audio is captured</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Used to save photos in a development app</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Used to view, select photos in a development app</string>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
`@capacitor/camera` requires this usage description for taking pictures.
You can verify in this app https://github.com/ionic-team/capacitor-testapp, go to camera page and try to take a picture, it will error.